### PR TITLE
make worker and master node ref variables

### DIFF
--- a/ansible/roles/master/files/addons/calico.yaml.j2
+++ b/ansible/roles/master/files/addons/calico.yaml.j2
@@ -46,6 +46,5 @@ calicoctl:
   tag: v3.28.2
 
 defaultFelixConfiguration:
-  enabled: "{{ calico_node_to_node_encryption | bool }}"
-  wireguardEnabled: "{{ calico_node_to_node_encryption | bool }}"
+  enabled: false
   logSeverityScreen: Info

--- a/terraform/master.tf
+++ b/terraform/master.tf
@@ -1,5 +1,5 @@
 resource "hcloud_server" "master-node" {
-  for_each = toset([for i in range(1, 4) : tostring(i)])
+  for_each = toset([for i in range(1, var.master_node_count) : tostring(i)])
   name        = "master-node-${each.key}"
   image       = "ubuntu-24.04"
   server_type = "cpx21"

--- a/terraform/templates/hosts.tpl
+++ b/terraform/templates/hosts.tpl
@@ -7,7 +7,7 @@ all:
           ansible_host: ${vm.public}
           ansible_user: haproxyadmin
           ip: ${vm.private}
-          ansible_ssh_private_key_file: ../keys/k8s_node
+          ansible_ssh_private_key_file: ../keys/vm_node
       %{ endfor }
     masters:
       hosts:
@@ -16,7 +16,7 @@ all:
           ansible_host: ${vm.public}
           ansible_user: cluster
           ip: ${vm.private}
-          ansible_ssh_private_key_file: ../keys/k8s_node
+          ansible_ssh_private_key_file: ../keys/vm_node
           extra:
             taints:
               - node-role.kubernetes.io/control-plane:NoSchedule-
@@ -28,7 +28,7 @@ all:
           ansible_host: ${vm.public}
           ansible_user: cluster
           ip: ${vm.private}
-          ansible_ssh_private_key_file: ../keys/k8s_node
+          ansible_ssh_private_key_file: ../keys/vm_node
           extra:
             taints:
               - glueops.dev/role=glueops-platform:NoSchedule

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,10 +10,6 @@ variable "master_node_count" {
   default = 3
 }
 
-variable "etcd_node_count" {
-  type = number
-  default = 3
-}
 variable "worker_node_count" {
   type = number
   default = 3

--- a/terraform/worker.tf
+++ b/terraform/worker.tf
@@ -1,5 +1,5 @@
 resource "hcloud_server" "worker-node" {
-  for_each = toset([for i in range(1, 3) : tostring(i)])
+  for_each = toset([for i in range(1, var.worker_node_count) : tostring(i)])
   # The name will be worker-node-0, worker-node-1, worker-node-2...
   name        = "worker-node-${each.key}"
   image       = "ubuntu-24.04"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Parameterized master and worker node counts in Terraform configs

- Updated SSH key reference in Ansible hosts template

- Disabled Calico node-to-node encryption by default


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>master.tf</strong><dd><code>Parameterize master node count in resource definition</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/master.tf

<li>Replaced hardcoded master node count with <code>var.master_node_count</code><br> <li> Enables dynamic scaling of master nodes via variable


</details>


  </td>
  <td><a href="https://github.com/GlueOps/GlueKube/pull/31/files#diff-821ba90c461305f74488a5c72226dfa2bca33626162704d0e1089f3299e6465e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worker.tf</strong><dd><code>Parameterize worker node count in resource definition</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/worker.tf

<li>Replaced hardcoded worker node count with <code>var.worker_node_count</code><br> <li> Supports dynamic worker node scaling via variable


</details>


  </td>
  <td><a href="https://github.com/GlueOps/GlueKube/pull/31/files#diff-6cf6eb1db6fa193742131cfe6d0d4583fc5aca6ab2320fb20f1239a26dfa7d5a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Confirm node count variables for master and worker nodes</code>&nbsp; </dd></summary>
<hr>

terraform/variables.tf

<li>Ensured <code>master_node_count</code> and <code>worker_node_count</code> variables are present<br> <li> No functional changes, but confirms variable usage for node counts


</details>


  </td>
  <td><a href="https://github.com/GlueOps/GlueKube/pull/31/files#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hosts.tpl</strong><dd><code>Update SSH key reference in Ansible hosts template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/templates/hosts.tpl

<li>Updated SSH private key file reference from <code>k8s_node</code> to <code>vm_node</code><br> <li> Applied change for loadbalancer, masters, and workers sections


</details>


  </td>
  <td><a href="https://github.com/GlueOps/GlueKube/pull/31/files#diff-707c1512919199f2df3472309f7ccd28e2ca68a40cefcb9306c87398c87780cf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>calico.yaml.j2</strong><dd><code>Disable Calico node-to-node encryption by default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/roles/master/files/addons/calico.yaml.j2

<li>Set <code>defaultFelixConfiguration.enabled</code> to <code>false</code><br> <li> Removed dynamic Wireguard encryption configuration<br> <li> Disables Calico node-to-node encryption by default


</details>


  </td>
  <td><a href="https://github.com/GlueOps/GlueKube/pull/31/files#diff-fb3f73261638c25db432c09deac1a2085ba3958e0826f1303ba881f973d7056d">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>